### PR TITLE
Disable no-prototype-builtins rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ module.exports = {
                 "before": false,
                 "after": true
             }
-        ]
+        ],
+        "no-prototype-builtins": "off"
     }
 };


### PR DESCRIPTION
Disable eslint rule as it does not provide much of a benefit for us and makes using methods like `hasOwnProperty` a hassle

https://eslint.org/docs/rules/no-prototype-builtins