### PR TITLE
feat: support new eslint version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,17 @@
 module.exports = {
-    extends: [
-        'eslint:recommended',
-        'plugin:@typescript-eslint/eslint-recommended',
-        'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking"
     ],
-    rules: {
-        "@typescript-eslint/consistent-type-assertions": 'off',
+    "rules": {
+        "@typescript-eslint/consistent-type-assertions": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/unbound-method": "off",
         "@typescript-eslint/no-unnecessary-type-assertion": "off",
         "@typescript-eslint/no-misused-promises": "off",
-        "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/ban-types": [
             "error",
             {
@@ -21,12 +20,21 @@ module.exports = {
                     "String": {
                         "message": "Use string instead",
                         "fixWith": "string"
+                    },
+                    "object": {
+                        "message": "The `object` type is currently hard to use ([see this issue](https://github.com/microsoft/TypeScript/issues/21732)). Consider using `Record<string, unknown>` instead, as it allows you to more easily inspect and use the keys."
                     }
                 }
             }
         ],
-        "@typescript-eslint/class-name-casing": [
-            "error"
+        "@typescript-eslint/naming-convention": [
+            "error",
+            {
+                "selector": "typeLike",
+                "format": [
+                    "PascalCase"
+                ]
+            }
         ],
         "@typescript-eslint/explicit-member-accessibility": [
             "error",
@@ -69,6 +77,7 @@ module.exports = {
                 "after": true
             }
         ],
-        "no-prototype-builtins": "off"
+        "no-prototype-builtins": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off"
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-phrase",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Phrase eslint rules",
   "license": "MIT",
   "main": "index.js",
@@ -11,8 +11,8 @@
   },
   "author": "Phrase",
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": ">= 2",
-    "@typescript-eslint/parser": ">= 2",
-    "eslint": ">= 6"
+    "@typescript-eslint/eslint-plugin": ">= 3",
+    "@typescript-eslint/parser": ">= 3",
+    "eslint": ">= 7"
   }
 }


### PR DESCRIPTION
Raised peerDep versions
Conform to new typescript-eslint rules

This could be merged to master only if we migrate all phrase repository to newest eslint